### PR TITLE
fix to show commit SHA hash in the same line

### DIFF
--- a/pagure/templates/file.html
+++ b/pagure/templates/file.html
@@ -66,8 +66,8 @@
                 repo=repo.name, identifier=branchname,
                 filename=filename + '/' + entry.name if filename else entry.name) }}">
         {{ entry.name }}
-        </a>
         <span class="filehex">{{ entry.hex|short }}</span>
+        </a>
     </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
The SHA in the Tree visually seemed to be coming in the next `<li>` element. This fixes the issue