### PR TITLE
Add Pillow to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ flask
 flask-wtf
 markdown
 munch
+Pillow
 psutil
 pygit2 >= 0.20.1
 pygments


### PR DESCRIPTION
pagure/ui/repo.py imports PIL but it is not mentioned in requirements.txt