### PR TITLE
#1084 Redirect .git extension in URL to repos page

### DIFF
--- a/pagure/ui/repo.py
+++ b/pagure/ui/repo.py
@@ -53,7 +53,7 @@ def view_repo(repo, username=None):
     """ Front page of a specific repo.
     """
     if '.' in repo:
-        repo_dot_split = rsplit('.',1)
+        repo_dot_split = repo.rsplit('.',1)
         repo = repo_dot_split[0]
         
     repo = pagure.lib.get_project(SESSION, repo, user=username)

--- a/pagure/ui/repo.py
+++ b/pagure/ui/repo.py
@@ -52,6 +52,10 @@ from pagure import (APP, SESSION, LOG, __get_file_in_tree, login_required,
 def view_repo(repo, username=None):
     """ Front page of a specific repo.
     """
+    if '.' in repo:
+        repo_dot_split = rsplit('.',1)
+        repo = repo_dot_split[0]
+        
     repo = pagure.lib.get_project(SESSION, repo, user=username)
 
     if repo is None:


### PR DESCRIPTION
used werkzeug.routing for using regex in routes to match string ending with only .git ext.