### PR TITLE
Add missing authentication provider option to documentation

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -578,14 +578,15 @@ PAGURE_AUTH
 ~~~~~~~~~~~~
 
 This configuration key specifies which authentication method to use.
-Pagure currently supports three authentication methods: the first one
-is relying on the Fedora Account System
-`FAS <https://admin.fedoraproject.org/accounts>`_, the second is using
-OpenID Connect (any provider) and the third is using only the local database.
-It can therefore be either ``fas``, ``oidc`` or ``local``.
+Valid options are ``fas``, ``openid``, ``oidc``, or ``local``.
 
-If ``oidc`` is used, the configuration options starting with ``OIDC_``
-(see below) must be provided.
+* ``fas`` uses the Fedora Account System `FAS <https://admin.fedoraproject.org/accounts>` to provide user authentication.
+
+* ``openid`` uses the Fedora Account System without requring users to sign the Fedora Project Contributor Agreement.
+
+* ``oidc`` enables OpenID Connect using any provider.  This provider requires the configuration options starting with ``OIDC_`` (see below) to be provided.
+
+* ``local`` causes pagure to use the local pagure database for user management.
 
 Defaults to: ``fas``.
 


### PR DESCRIPTION
Updated documentation to provide information regarding the openid provider.
This provider allows pagure to use FAS without requiring users to sign
the FPCA.